### PR TITLE
Fix grey box on pages that don't scroll

### DIFF
--- a/sphinx_pdj_theme/static/css/darker.css
+++ b/sphinx_pdj_theme/static/css/darker.css
@@ -62,7 +62,6 @@ codeblock, pre.literal-block, .rst-content .literal-block, .rst-content pre.lite
 
 .wy-nav-content-wrap{
     margin-left: 200px;
-    background: #343131;
 }
 
 .hentry {


### PR DESCRIPTION
This background color causes a grey box to appear at the bottom on pages that don't scroll. As far as I can tell removing it causes no issues since it just inherits from another CSS class with the correct color